### PR TITLE
feat: swap exact out

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
     "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
-    "test": "anchor build -- --features local && yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/*.test.ts"
+    "test": "anchor build -- --features local && ts-mocha -p ./tsconfig.json -t 1000000 tests/*.test.ts"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.0"

--- a/programs/cp-amm/src/event.rs
+++ b/programs/cp-amm/src/event.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 
 use crate::{
     params::fee_parameters::PoolFeeParameters, state::SwapResult, AddLiquidityParameters,
-    RemoveLiquidityParameters, SwapParameters,
+    RemoveLiquidityParameters, SwapExactInParameters, SwapParameters,
 };
 
 /// Close config
@@ -258,4 +258,15 @@ pub struct EvtWithdrawIneligibleReward {
     pub reward_mint: Pubkey,
     // Amount of ineligible reward withdrawn
     pub amount: u64,
+}
+
+#[event]
+pub struct EvtSwapExactIn {
+    pub pool: Pubkey,
+    pub trade_direction: u8,
+    pub has_referral: bool,
+    pub params: SwapExactInParameters,
+    pub swap_result: SwapResult,
+    pub actual_amount_in: u64,
+    pub current_timestamp: u64,
 }

--- a/programs/cp-amm/src/event.rs
+++ b/programs/cp-amm/src/event.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 
 use crate::{
     params::fee_parameters::PoolFeeParameters, state::SwapResult, AddLiquidityParameters,
-    RemoveLiquidityParameters, SwapExactInParameters, SwapParameters,
+    RemoveLiquidityParameters, SwapExactInParameters, SwapExactOutParameters, SwapParameters,
 };
 
 /// Close config
@@ -266,6 +266,17 @@ pub struct EvtSwapExactIn {
     pub trade_direction: u8,
     pub has_referral: bool,
     pub params: SwapExactInParameters,
+    pub swap_result: SwapResult,
+    pub actual_amount_in: u64,
+    pub current_timestamp: u64,
+}
+
+#[event]
+pub struct EvtSwapExactOut {
+    pub pool: Pubkey,
+    pub trade_direction: u8,
+    pub has_referral: bool,
+    pub params: SwapExactOutParameters,
     pub swap_result: SwapResult,
     pub actual_amount_in: u64,
     pub current_timestamp: u64,

--- a/programs/cp-amm/src/instructions/ix_swap.rs
+++ b/programs/cp-amm/src/instructions/ix_swap.rs
@@ -6,7 +6,7 @@ use crate::{
     constants::seeds::POOL_AUTHORITY_PREFIX,
     get_pool_access_validator,
     params::swap::TradeDirection,
-    state::{fee::FeeMode, Pool},
+    state::{fee::FeeMode, Pool, SwapMode},
     token::{calculate_transfer_fee_excluded_amount, transfer_from_pool, transfer_from_user},
     EvtSwap, PoolError,
 };
@@ -138,7 +138,7 @@ pub fn handle_swap(ctx: Context<SwapCtx>, params: SwapParameters) -> Result<()> 
     let current_point = ActivationHandler::get_current_point(pool.activation_type)?;
     let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, has_referral)?;
 
-    let swap_result = pool.get_swap_result(
+    let swap_result = pool.get_swap_result_with_amount_in(
         transfer_fee_excluded_amount_in,
         fee_mode,
         trade_direction,

--- a/programs/cp-amm/src/instructions/ix_swap.rs
+++ b/programs/cp-amm/src/instructions/ix_swap.rs
@@ -6,7 +6,7 @@ use crate::{
     constants::seeds::POOL_AUTHORITY_PREFIX,
     get_pool_access_validator,
     params::swap::TradeDirection,
-    state::{fee::FeeMode, Pool, SwapMode},
+    state::{fee::FeeMode, Pool},
     token::{calculate_transfer_fee_excluded_amount, transfer_from_pool, transfer_from_user},
     EvtSwap, PoolError,
 };

--- a/programs/cp-amm/src/instructions/ix_swap_exact_in.rs
+++ b/programs/cp-amm/src/instructions/ix_swap_exact_in.rs
@@ -7,7 +7,7 @@ use crate::{
     constants::seeds::POOL_AUTHORITY_PREFIX,
     get_pool_access_validator,
     params::swap::TradeDirection,
-    state::{fee::FeeMode, Pool},
+    state::{fee::FeeMode, Pool, SwapMode},
     token::{
         calculate_transfer_fee_excluded_amount, transfer_from_pool, transfer_from_user,
         TransferFeeExcludedAmount,
@@ -123,7 +123,7 @@ pub fn handle_swap_exact_in(
         ),
     };
 
-    // Fee in
+    // Transfer-in fee (Token Extension)
     let TransferFeeExcludedAmount {
         amount: transfer_fee_excluded_amount_in,
         ..
@@ -146,14 +146,14 @@ pub fn handle_swap_exact_in(
     pool.update_pre_swap(current_timestamp)?;
 
     // Swap
-    let swap_result = pool.get_swap_result(
+    let swap_result = pool.get_swap_result_with_amount_in(
         transfer_fee_excluded_amount_in,
         fee_mode,
         trade_direction,
         current_point,
     )?;
 
-    // Fee out
+    // Transfer-out fee (Token Extension)
     let TransferFeeExcludedAmount {
         amount: transfer_fee_excluded_amount_out,
         ..

--- a/programs/cp-amm/src/instructions/ix_swap_exact_in.rs
+++ b/programs/cp-amm/src/instructions/ix_swap_exact_in.rs
@@ -1,0 +1,225 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
+use num::ToPrimitive;
+
+use crate::{
+    activation_handler::ActivationHandler,
+    constants::seeds::POOL_AUTHORITY_PREFIX,
+    get_pool_access_validator,
+    params::swap::TradeDirection,
+    state::{fee::FeeMode, Pool},
+    token::{
+        calculate_transfer_fee_excluded_amount, transfer_from_pool, transfer_from_user,
+        TransferFeeExcludedAmount,
+    },
+    EvtSwapExactIn, PoolError,
+};
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct SwapExactInParameters {
+    amount_in: u64,
+    minimum_amount_out: u64,
+}
+
+#[event_cpi]
+#[derive(Accounts)]
+pub struct SwapExactInCtx<'info> {
+    /// CHECK: Pool Authority
+    #[account(seeds = [POOL_AUTHORITY_PREFIX.as_ref()], bump)]
+    pub pool_authority: UncheckedAccount<'info>,
+
+    /// Pool account
+    #[account(mut, has_one = token_a_vault, has_one = token_b_vault)]
+    pub pool: AccountLoader<'info, Pool>,
+
+    /// The user token account for input token
+    #[account(mut)]
+    pub input_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// The user token account for output token
+    #[account(mut)]
+    pub output_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// The vault token account for input token
+    #[account(mut, token::token_program = token_a_program, token::mint = token_a_mint)]
+    pub token_a_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// The vault token account for output token
+    #[account(mut, token::token_program = token_b_program, token::mint = token_b_mint)]
+    pub token_b_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// The mint of token a
+    pub token_a_mint: Box<InterfaceAccount<'info, Mint>>,
+
+    /// The mint of token b
+    pub token_b_mint: Box<InterfaceAccount<'info, Mint>>,
+
+    /// The user performing the swap
+    pub payer: Signer<'info>,
+
+    /// Token a program
+    pub token_a_program: Interface<'info, TokenInterface>,
+
+    /// Token b program
+    pub token_b_program: Interface<'info, TokenInterface>,
+
+    /// Referral token account
+    #[account(mut)]
+    pub referral_token_account: Option<Box<InterfaceAccount<'info, TokenAccount>>>,
+}
+
+impl<'info> SwapExactInCtx<'info> {
+    /// Get the trading direction of the current swap. Eg: USDT -> USDC
+    pub fn get_trade_direction(&self) -> TradeDirection {
+        if self.input_token_account.mint == self.token_a_mint.key() {
+            return TradeDirection::AtoB;
+        }
+        TradeDirection::BtoA
+    }
+}
+
+pub fn handle_swap_exact_in(
+    ctx: Context<SwapExactInCtx>,
+    params: SwapExactInParameters,
+) -> Result<()> {
+    {
+        let pool = ctx.accounts.pool.load()?;
+        let access_validator = get_pool_access_validator(&pool)?;
+        require!(
+            access_validator.can_swap(&ctx.accounts.payer.key()),
+            PoolError::PoolDisabled
+        );
+    }
+
+    let SwapExactInParameters {
+        amount_in,
+        minimum_amount_out,
+    } = params;
+
+    let trade_direction = ctx.accounts.get_trade_direction();
+    let (
+        token_in_mint,
+        token_out_mint,
+        input_vault_account,
+        output_vault_account,
+        input_program,
+        output_program,
+    ) = match trade_direction {
+        TradeDirection::AtoB => (
+            &ctx.accounts.token_a_mint,
+            &ctx.accounts.token_b_mint,
+            &ctx.accounts.token_a_vault,
+            &ctx.accounts.token_b_vault,
+            &ctx.accounts.token_a_program,
+            &ctx.accounts.token_b_program,
+        ),
+        TradeDirection::BtoA => (
+            &ctx.accounts.token_b_mint,
+            &ctx.accounts.token_a_mint,
+            &ctx.accounts.token_b_vault,
+            &ctx.accounts.token_a_vault,
+            &ctx.accounts.token_b_program,
+            &ctx.accounts.token_a_program,
+        ),
+    };
+
+    // Fee in
+    let TransferFeeExcludedAmount {
+        amount: transfer_fee_excluded_amount_in,
+        ..
+    } = calculate_transfer_fee_excluded_amount(&token_in_mint, amount_in)?;
+    require!(transfer_fee_excluded_amount_in > 0, PoolError::AmountIsZero);
+
+    // Referral
+    let has_referral = ctx.accounts.referral_token_account.is_some();
+
+    // Basic info
+    let mut pool = ctx.accounts.pool.load_mut()?;
+    let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, has_referral)?;
+    let current_timestamp = Clock::get()?
+        .unix_timestamp
+        .to_u64()
+        .ok_or(PoolError::MathOverflow)?;
+    let current_point = ActivationHandler::get_current_point(pool.activation_type)?;
+
+    // Update for dynamic fee references
+    pool.update_pre_swap(current_timestamp)?;
+
+    // Swap
+    let swap_result = pool.get_swap_result(
+        transfer_fee_excluded_amount_in,
+        fee_mode,
+        trade_direction,
+        current_point,
+    )?;
+
+    // Fee out
+    let TransferFeeExcludedAmount {
+        amount: transfer_fee_excluded_amount_out,
+        ..
+    } = calculate_transfer_fee_excluded_amount(&token_out_mint, swap_result.output_amount)?;
+    require!(
+        transfer_fee_excluded_amount_out >= minimum_amount_out,
+        PoolError::ExceededSlippage
+    );
+
+    // Apply the swap result
+    pool.apply_swap_result(&swap_result, fee_mode, current_timestamp)?;
+
+    // Send to reserves
+    transfer_from_user(
+        &ctx.accounts.payer,
+        token_in_mint,
+        &ctx.accounts.input_token_account,
+        &input_vault_account,
+        input_program,
+        amount_in,
+    )?;
+    // Send to the user
+    transfer_from_pool(
+        ctx.accounts.pool_authority.to_account_info(),
+        &token_out_mint,
+        &output_vault_account,
+        &ctx.accounts.output_token_account,
+        output_program,
+        swap_result.output_amount,
+        ctx.bumps.pool_authority,
+    )?;
+    // Reward the referrer
+    if has_referral {
+        let (reward_mint, reward_vault, reward_token_program) = if fee_mode.fees_on_token_a {
+            (
+                &ctx.accounts.token_a_mint,
+                &ctx.accounts.token_a_vault,
+                &ctx.accounts.token_a_program,
+            )
+        } else {
+            (
+                &ctx.accounts.token_b_mint,
+                &ctx.accounts.token_b_vault,
+                &ctx.accounts.token_b_program,
+            )
+        };
+        transfer_from_pool(
+            ctx.accounts.pool_authority.to_account_info(),
+            reward_mint,
+            reward_vault,
+            &ctx.accounts.referral_token_account.clone().unwrap(),
+            reward_token_program,
+            swap_result.referral_fee,
+            ctx.bumps.pool_authority,
+        )?;
+    }
+
+    emit_cpi!(EvtSwapExactIn {
+        pool: ctx.accounts.pool.key(),
+        trade_direction: trade_direction.into(),
+        params,
+        swap_result,
+        has_referral,
+        actual_amount_in: transfer_fee_excluded_amount_in,
+        current_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/cp-amm/src/instructions/ix_swap_exact_in.rs
+++ b/programs/cp-amm/src/instructions/ix_swap_exact_in.rs
@@ -7,7 +7,7 @@ use crate::{
     constants::seeds::POOL_AUTHORITY_PREFIX,
     get_pool_access_validator,
     params::swap::TradeDirection,
-    state::{fee::FeeMode, Pool, SwapMode},
+    state::{fee::FeeMode, Pool},
     token::{
         calculate_transfer_fee_excluded_amount, transfer_from_pool, transfer_from_user,
         TransferFeeExcludedAmount,

--- a/programs/cp-amm/src/instructions/ix_swap_exact_out.rs
+++ b/programs/cp-amm/src/instructions/ix_swap_exact_out.rs
@@ -1,0 +1,234 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
+use num::ToPrimitive;
+
+use crate::{
+    activation_handler::ActivationHandler,
+    constants::seeds::POOL_AUTHORITY_PREFIX,
+    get_pool_access_validator,
+    params::swap::TradeDirection,
+    safe_math::SafeMath,
+    state::{fee::FeeMode, Pool},
+    token::{
+        calculate_transfer_fee_included_amount, transfer_from_pool, transfer_from_user,
+        TransferFeeIncludedAmount,
+    },
+    EvtSwapExactOut, PoolError,
+};
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct SwapExactOutParameters {
+    amount_out: u64,
+    maximum_amount_in: u64,
+}
+
+#[event_cpi]
+#[derive(Accounts)]
+pub struct SwapExactOutCtx<'info> {
+    /// CHECK: Pool Authority
+    #[account(seeds = [POOL_AUTHORITY_PREFIX.as_ref()], bump)]
+    pub pool_authority: UncheckedAccount<'info>,
+
+    /// Pool account
+    #[account(mut, has_one = token_a_vault, has_one = token_b_vault)]
+    pub pool: AccountLoader<'info, Pool>,
+
+    /// The user token account for input token
+    #[account(mut)]
+    pub input_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// The user token account for output token
+    #[account(mut)]
+    pub output_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// The vault token account for input token
+    #[account(mut, token::token_program = token_a_program, token::mint = token_a_mint)]
+    pub token_a_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// The vault token account for output token
+    #[account(mut, token::token_program = token_b_program, token::mint = token_b_mint)]
+    pub token_b_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// The mint of token a
+    pub token_a_mint: Box<InterfaceAccount<'info, Mint>>,
+
+    /// The mint of token b
+    pub token_b_mint: Box<InterfaceAccount<'info, Mint>>,
+
+    /// The user performing the swap
+    pub payer: Signer<'info>,
+
+    /// Token a program
+    pub token_a_program: Interface<'info, TokenInterface>,
+
+    /// Token b program
+    pub token_b_program: Interface<'info, TokenInterface>,
+
+    /// Referral token account
+    #[account(mut)]
+    pub referral_token_account: Option<Box<InterfaceAccount<'info, TokenAccount>>>,
+}
+
+impl<'info> SwapExactOutCtx<'info> {
+    /// Get the trading direction of the current swap. Eg: USDT -> USDC
+    pub fn get_trade_direction(&self) -> TradeDirection {
+        if self.input_token_account.mint == self.token_a_mint.key() {
+            return TradeDirection::AtoB;
+        }
+        TradeDirection::BtoA
+    }
+}
+
+pub fn handle_swap_exact_out(
+    ctx: Context<SwapExactOutCtx>,
+    params: SwapExactOutParameters,
+) -> Result<()> {
+    {
+        let pool = ctx.accounts.pool.load()?;
+        let access_validator = get_pool_access_validator(&pool)?;
+        require!(
+            access_validator.can_swap(&ctx.accounts.payer.key()),
+            PoolError::PoolDisabled
+        );
+    }
+
+    let SwapExactOutParameters {
+        amount_out,
+        maximum_amount_in,
+    } = params;
+
+    let trade_direction = ctx.accounts.get_trade_direction();
+    let (
+        token_in_mint,
+        token_out_mint,
+        input_vault_account,
+        output_vault_account,
+        input_program,
+        output_program,
+    ) = match trade_direction {
+        TradeDirection::AtoB => (
+            &ctx.accounts.token_a_mint,
+            &ctx.accounts.token_b_mint,
+            &ctx.accounts.token_a_vault,
+            &ctx.accounts.token_b_vault,
+            &ctx.accounts.token_a_program,
+            &ctx.accounts.token_b_program,
+        ),
+        TradeDirection::BtoA => (
+            &ctx.accounts.token_b_mint,
+            &ctx.accounts.token_a_mint,
+            &ctx.accounts.token_b_vault,
+            &ctx.accounts.token_a_vault,
+            &ctx.accounts.token_b_program,
+            &ctx.accounts.token_a_program,
+        ),
+    };
+
+    // Transfer-out fee (Token Extension)
+    require!(amount_out > 0, PoolError::AmountIsZero);
+    let TransferFeeIncludedAmount {
+        amount: transfer_fee_included_amount,
+        ..
+    } = calculate_transfer_fee_included_amount(&token_out_mint, amount_out)?;
+
+    // Referral
+    let has_referral = ctx.accounts.referral_token_account.is_some();
+
+    // Basic info
+    let mut pool = ctx.accounts.pool.load_mut()?;
+    let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, has_referral)?;
+    let current_timestamp = Clock::get()?
+        .unix_timestamp
+        .to_u64()
+        .ok_or(PoolError::MathOverflow)?;
+    let current_point = ActivationHandler::get_current_point(pool.activation_type)?;
+
+    // Update for dynamic fee references
+    pool.update_pre_swap(current_timestamp)?;
+
+    // Swap
+    let swap_result = pool.get_swap_result_with_amount_out(
+        transfer_fee_included_amount,
+        fee_mode,
+        trade_direction,
+        current_point,
+    )?;
+
+    // Get the theoretical (before-tax) input amount
+    let actual_amount_in = swap_result.input_amount;
+    let input_amount = actual_amount_in
+        .safe_add(swap_result.lp_fee)?
+        .safe_add(swap_result.protocol_fee)?
+        .safe_add(swap_result.partner_fee)?
+        .safe_add(swap_result.referral_fee)?;
+
+    // Transfer-in fee (Token Extension)
+    let TransferFeeIncludedAmount {
+        amount: transfer_fee_included_amount_in,
+        ..
+    } = calculate_transfer_fee_included_amount(&token_in_mint, input_amount)?;
+    require!(
+        maximum_amount_in >= transfer_fee_included_amount_in,
+        PoolError::ExceededSlippage
+    );
+
+    // Apply the swap result
+    pool.apply_swap_result(&swap_result, fee_mode, current_timestamp)?;
+
+    // Send to reserves
+    transfer_from_user(
+        &ctx.accounts.payer,
+        token_in_mint,
+        &ctx.accounts.input_token_account,
+        &input_vault_account,
+        input_program,
+        transfer_fee_included_amount_in,
+    )?;
+    // Send to the user
+    transfer_from_pool(
+        ctx.accounts.pool_authority.to_account_info(),
+        &token_out_mint,
+        &output_vault_account,
+        &ctx.accounts.output_token_account,
+        output_program,
+        swap_result.output_amount,
+        ctx.bumps.pool_authority,
+    )?;
+    // Reward the referrer
+    if has_referral {
+        let (reward_mint, reward_vault, reward_token_program) = if fee_mode.fees_on_token_a {
+            (
+                &ctx.accounts.token_a_mint,
+                &ctx.accounts.token_a_vault,
+                &ctx.accounts.token_a_program,
+            )
+        } else {
+            (
+                &ctx.accounts.token_b_mint,
+                &ctx.accounts.token_b_vault,
+                &ctx.accounts.token_b_program,
+            )
+        };
+        transfer_from_pool(
+            ctx.accounts.pool_authority.to_account_info(),
+            reward_mint,
+            reward_vault,
+            &ctx.accounts.referral_token_account.clone().unwrap(),
+            reward_token_program,
+            swap_result.referral_fee,
+            ctx.bumps.pool_authority,
+        )?;
+    }
+
+    emit_cpi!(EvtSwapExactOut {
+        pool: ctx.accounts.pool.key(),
+        trade_direction: trade_direction.into(),
+        params,
+        swap_result,
+        has_referral,
+        actual_amount_in,
+        current_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/cp-amm/src/instructions/mod.rs
+++ b/programs/cp-amm/src/instructions/mod.rs
@@ -28,3 +28,5 @@ pub mod ix_withdraw_ineligible_reward;
 pub use ix_withdraw_ineligible_reward::*;
 pub mod ix_close_position;
 pub use ix_close_position::*;
+pub mod ix_swap_exact_in;
+pub use ix_swap_exact_in::*;

--- a/programs/cp-amm/src/instructions/mod.rs
+++ b/programs/cp-amm/src/instructions/mod.rs
@@ -30,3 +30,5 @@ pub mod ix_close_position;
 pub use ix_close_position::*;
 pub mod ix_swap_exact_in;
 pub use ix_swap_exact_in::*;
+pub mod ix_swap_exact_out;
+pub use ix_swap_exact_out::*;

--- a/programs/cp-amm/src/lib.rs
+++ b/programs/cp-amm/src/lib.rs
@@ -227,4 +227,11 @@ pub mod cp_amm {
     ) -> Result<()> {
         instructions::handle_claim_reward(ctx, reward_index, skip_reward)
     }
+
+    pub fn swap_exact_in(
+        ctx: Context<SwapExactInCtx>,
+        params: SwapExactInParameters,
+    ) -> Result<()> {
+        instructions::handle_swap_exact_in(ctx, params)
+    }
 }

--- a/programs/cp-amm/src/tests/integration_tests.rs
+++ b/programs/cp-amm/src/tests/integration_tests.rs
@@ -210,7 +210,7 @@ fn execute_swap_liquidity(
     let fee_mode =
         &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, has_referral).unwrap();
     let swap_result = pool
-        .get_swap_result(amount_in, fee_mode, trade_direction, 0)
+        .get_swap_result_with_amount_in(amount_in, fee_mode, trade_direction, 0)
         .unwrap();
 
     pool.apply_swap_result(&swap_result, fee_mode, 0).unwrap();

--- a/programs/cp-amm/src/tests/mod.rs
+++ b/programs/cp-amm/src/tests/mod.rs
@@ -5,6 +5,12 @@ pub const LIQUIDITY_MAX: u128 = 34028236692093846346337460743;
 mod swap_tests;
 
 #[cfg(test)]
+mod swap_exact_in_tests;
+
+#[cfg(test)]
+mod swap_exact_out_tests;
+
+#[cfg(test)]
 mod modify_liquidity_tests;
 
 #[cfg(test)]

--- a/programs/cp-amm/src/tests/swap_exact_in_tests.rs
+++ b/programs/cp-amm/src/tests/swap_exact_in_tests.rs
@@ -1,0 +1,224 @@
+use std::{u128, u64};
+
+use crate::{
+    constants::{MAX_SQRT_PRICE, MIN_SQRT_PRICE},
+    curve::get_initialize_amounts,
+    params::swap::TradeDirection,
+    safe_math::SafeMath,
+    state::{fee::FeeMode, Pool},
+    tests::LIQUIDITY_MAX,
+};
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 10000, .. ProptestConfig::default()
+    })]
+
+    #[test]
+    fn test_reserve_wont_lost_when_swap_from_a_to_b(
+        sqrt_price in MIN_SQRT_PRICE..=MAX_SQRT_PRICE,
+        amount_in in 1..=u64::MAX,
+        liquidity in 1..=LIQUIDITY_MAX,
+    ) {
+        let mut pool = Pool {
+            liquidity,
+            sqrt_price,
+            sqrt_min_price: MIN_SQRT_PRICE,
+            sqrt_max_price: MAX_SQRT_PRICE,
+            ..Default::default()
+        };
+
+        let trade_direction = TradeDirection::AtoB;
+
+        let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, false).unwrap();
+        let max_amount_in = pool.get_max_amount_in(trade_direction).unwrap();
+        if amount_in <= max_amount_in {
+            let swap_result_0 = pool
+            .get_swap_result_with_amount_in(amount_in, fee_mode, trade_direction, 0)
+            .unwrap();
+
+            pool.apply_swap_result(&swap_result_0, fee_mode, 0).unwrap();
+            // swap back
+
+            let swap_result_1 = pool
+            .get_swap_result_with_amount_in(swap_result_0.output_amount, fee_mode, TradeDirection::BtoA, 0)
+            .unwrap();
+
+            assert!(swap_result_1.output_amount < amount_in);
+        }
+    }
+
+    #[test]
+    fn test_reserve_wont_lost_when_swap_from_b_to_a(
+        sqrt_price in MIN_SQRT_PRICE..=MAX_SQRT_PRICE,
+        amount_in in 1..=u64::MAX,
+        liquidity in 1..=LIQUIDITY_MAX,
+    ) {
+        let mut pool = Pool {
+            liquidity,
+            sqrt_price,
+            sqrt_min_price: MIN_SQRT_PRICE,
+            sqrt_max_price: MAX_SQRT_PRICE,
+            ..Default::default()
+        };
+
+        let trade_direction = TradeDirection::BtoA;
+
+        let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, false).unwrap();
+        let max_amount_in = pool.get_max_amount_in(trade_direction).unwrap();
+        if amount_in <= max_amount_in {
+            let swap_result_0 = pool
+            .get_swap_result_with_amount_in(amount_in, fee_mode, trade_direction, 0)
+            .unwrap();
+
+            pool.apply_swap_result(&swap_result_0, fee_mode, 0).unwrap();
+            // swap back
+
+            let swap_result_1 = pool
+            .get_swap_result_with_amount_in(swap_result_0.output_amount, fee_mode, TradeDirection::AtoB, 0)
+            .unwrap();
+
+            assert!(swap_result_1.output_amount < amount_in);
+        }
+    }
+}
+
+// #[test]
+// fn test_reserve_wont_lost_when_swap_from_a_to_b_single() {
+//     let liquidity = 1;
+//     let sqrt_price = 4295048016;
+//     let amount_in = 35;
+//     let trade_direction = TradeDirection::AtoB;
+//     let mut pool = Pool {
+//         liquidity,
+//         sqrt_price,
+//         sqrt_min_price: MIN_SQRT_PRICE,
+//         sqrt_max_price: MAX_SQRT_PRICE,
+//         ..Default::default()
+//     };
+
+//     let swap_result_0 = pool
+//         .get_swap_result_with_amount_in(amount_in, false, trade_direction)
+//         .unwrap();
+
+//     println!("{:?}", swap_result_0);
+
+//     pool.apply_swap_result(&swap_result_0, trade_direction)
+//         .unwrap();
+
+//     let swap_result_1 = pool
+//         .get_swap_result_with_amount_in(swap_result_0.output_amount, false, TradeDirection::BtoA)
+//         .unwrap();
+
+//     println!("{:?}", swap_result_1);
+
+//     assert!(swap_result_1.output_amount < amount_in);
+// }
+
+#[test]
+fn test_reserve_wont_lost_when_swap_from_b_to_a_single() {
+    let liquidity = LIQUIDITY_MAX;
+    let sqrt_price = 19163436944492510497018124036;
+    let amount_in = 1_000_0000;
+    let trade_direction = TradeDirection::BtoA;
+    let mut pool = Pool {
+        liquidity,
+        sqrt_price,
+        sqrt_min_price: MIN_SQRT_PRICE,
+        sqrt_max_price: MAX_SQRT_PRICE,
+        ..Default::default()
+    };
+    let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, false).unwrap();
+    let swap_result_0 = pool
+        .get_swap_result_with_amount_in(amount_in, fee_mode, trade_direction, 0)
+        .unwrap();
+
+    println!("{:?}", swap_result_0);
+
+    pool.apply_swap_result(&swap_result_0, fee_mode, 0).unwrap();
+
+    let swap_result_1 = pool
+        .get_swap_result_with_amount_in(
+            swap_result_0.output_amount,
+            fee_mode,
+            TradeDirection::AtoB,
+            0,
+        )
+        .unwrap();
+
+    println!("{:?}", swap_result_1);
+
+    assert!(swap_result_1.output_amount < amount_in);
+}
+
+#[test]
+fn test_swap_basic() {
+    // let pool_fees = PoolFeesStruct {
+    //     trade_fee_numerator: 1_000_000, //1%
+    //     protocol_fee_percent: 20,
+    //     partner_fee_percent: 50,
+    //     referral_fee_percent: 20,
+    //     ..Default::default()
+    // };
+    let sqrt_min_price = MIN_SQRT_PRICE;
+    let sqrt_max_price = MAX_SQRT_PRICE;
+    let sqrt_price = u64::MAX as u128;
+    let liquidity = LIQUIDITY_MAX;
+    let mut pool = Pool {
+        // pool_fees,
+        ..Default::default()
+    };
+
+    let (_token_a_amount, _token_b_amount) =
+        get_initialize_amounts(sqrt_min_price, sqrt_max_price, sqrt_price, liquidity).unwrap();
+    // println!("amount {} {}", _token_a_amount, _token_b_amount);
+    pool.liquidity = liquidity;
+    pool.sqrt_max_price = sqrt_max_price;
+    pool.sqrt_min_price = sqrt_min_price;
+    pool.sqrt_price = sqrt_price;
+
+    // let next_sqrt_price =
+    //     get_next_sqrt_price_from_input(sqrt_price, liquidity, 100_000_000, true).unwrap();
+
+    // println!(
+    //     "price {} {} {}",
+    //     to_decimal(sqrt_price),
+    //     to_decimal(next_sqrt_price),
+    //     liquidity.safe_shr(64).unwrap(),
+    // );
+
+    let amount_in = 100_000_000;
+    let trade_direction = TradeDirection::AtoB;
+    let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, false).unwrap();
+
+    let swap_result = pool
+        .get_swap_result_with_amount_in(amount_in, fee_mode, trade_direction, 0)
+        .unwrap();
+
+    println!("result {:?}", swap_result);
+
+    // return;
+
+    pool.apply_swap_result(&swap_result, fee_mode, 0).unwrap();
+
+    let swap_result_referse = pool
+        .get_swap_result_with_amount_in(
+            swap_result.output_amount,
+            fee_mode,
+            TradeDirection::BtoA,
+            0,
+        )
+        .unwrap();
+
+    println!("reverse {:?}", swap_result_referse);
+    assert!(swap_result_referse.output_amount <= amount_in);
+}
+
+#[test]
+fn test_basic_math() {
+    let liquidity = LIQUIDITY_MAX;
+    let quote_1 = liquidity.safe_shr(64).unwrap();
+    let quote_2 = liquidity.safe_div(1.safe_shl(64).unwrap()).unwrap();
+    assert_eq!(quote_1, quote_2);
+}

--- a/programs/cp-amm/src/tests/swap_exact_out_tests.rs
+++ b/programs/cp-amm/src/tests/swap_exact_out_tests.rs
@@ -1,0 +1,123 @@
+use std::u64;
+
+use crate::{
+    constants::{MAX_SQRT_PRICE, MIN_SQRT_PRICE},
+    curve::get_initialize_amounts,
+    params::swap::TradeDirection,
+    state::{fee::FeeMode, Pool},
+    tests::LIQUIDITY_MAX,
+};
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 10000, .. ProptestConfig::default()
+    })]
+
+    #[test]
+    fn test_reserve_wont_lost_when_swap_from_a_to_b(
+        sqrt_price in MIN_SQRT_PRICE..=MAX_SQRT_PRICE,
+        amount_out in 1..=u64::MAX,
+        liquidity in 1..=LIQUIDITY_MAX,
+    ) {
+        let mut pool = Pool {
+            liquidity,
+            sqrt_price,
+            sqrt_min_price: MIN_SQRT_PRICE,
+            sqrt_max_price: MAX_SQRT_PRICE,
+            ..Default::default()
+        };
+
+        let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, TradeDirection::AtoB, false).unwrap();
+        let max_amount_out = pool.get_max_amount_out(TradeDirection::AtoB).unwrap();
+        if amount_out <= max_amount_out {
+            let swap_result_forward = pool
+            .get_swap_result_with_amount_out(amount_out, fee_mode, TradeDirection::AtoB, 0)
+            .unwrap();
+
+            pool.apply_swap_result(&swap_result_forward, fee_mode, 0).unwrap();
+            // swap back
+
+            let swap_result_backward = pool
+            .get_swap_result_with_amount_in(swap_result_forward.output_amount, fee_mode, TradeDirection::BtoA, 0)
+            .unwrap();
+
+            assert!(swap_result_forward.output_amount == amount_out);
+            assert!(swap_result_forward.input_amount > swap_result_backward.output_amount);
+        }
+    }
+
+    #[test]
+    fn test_reserve_wont_lost_when_swap_from_b_to_a(
+        sqrt_price in MIN_SQRT_PRICE..=MAX_SQRT_PRICE,
+        amount_out in 1..=u64::MAX,
+        liquidity in 1..=LIQUIDITY_MAX,
+    ) {
+        let mut pool = Pool {
+            liquidity,
+            sqrt_price,
+            sqrt_min_price: MIN_SQRT_PRICE,
+            sqrt_max_price: MAX_SQRT_PRICE,
+            ..Default::default()
+        };
+
+        let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, TradeDirection::BtoA, false).unwrap();
+        let max_amount_out = pool.get_max_amount_out(TradeDirection::BtoA).unwrap();
+        if amount_out <= max_amount_out {
+            let swap_result_forward = pool
+            .get_swap_result_with_amount_out(amount_out, fee_mode, TradeDirection::BtoA, 0)
+            .unwrap();
+
+            pool.apply_swap_result(&swap_result_forward, fee_mode, 0).unwrap();
+            // swap back
+
+            let swap_result_backward = pool
+            .get_swap_result_with_amount_in(swap_result_forward.output_amount, fee_mode, TradeDirection::AtoB, 0)
+            .unwrap();
+
+            assert!(swap_result_forward.output_amount == amount_out);
+            assert!(swap_result_forward.input_amount > swap_result_backward.output_amount);
+        }
+    }
+}
+
+#[test]
+fn test_swap_basic() {
+    let sqrt_min_price = MIN_SQRT_PRICE;
+    let sqrt_max_price = MAX_SQRT_PRICE;
+    let sqrt_price = u64::MAX as u128;
+    let liquidity = LIQUIDITY_MAX;
+    let mut pool = Pool {
+        ..Default::default()
+    };
+
+    let (_token_a_amount, _token_b_amount) =
+        get_initialize_amounts(sqrt_min_price, sqrt_max_price, sqrt_price, liquidity).unwrap();
+    pool.liquidity = liquidity;
+    pool.sqrt_max_price = sqrt_max_price;
+    pool.sqrt_min_price = sqrt_min_price;
+    pool.sqrt_price = sqrt_price;
+
+    let amount_out = 100_000_000;
+    let trade_direction = TradeDirection::AtoB;
+    let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, false).unwrap();
+
+    let swap_result_forward = pool
+        .get_swap_result_with_amount_out(amount_out, fee_mode, trade_direction, 0)
+        .unwrap();
+
+    pool.apply_swap_result(&swap_result_forward, fee_mode, 0)
+        .unwrap();
+
+    let swap_result_backward = pool
+        .get_swap_result_with_amount_out(
+            swap_result_forward.input_amount,
+            fee_mode,
+            TradeDirection::BtoA,
+            0,
+        )
+        .unwrap();
+
+    assert!(swap_result_forward.output_amount == amount_out);
+    assert!(swap_result_forward.input_amount >= swap_result_backward.output_amount);
+}

--- a/programs/cp-amm/src/tests/swap_tests.rs
+++ b/programs/cp-amm/src/tests/swap_tests.rs
@@ -34,14 +34,14 @@ proptest! {
         let max_amount_in = pool.get_max_amount_in(trade_direction).unwrap();
         if amount_in <= max_amount_in {
             let swap_result_0 = pool
-            .get_swap_result(amount_in, fee_mode, trade_direction, 0)
+            .get_swap_result_with_amount_in(amount_in, fee_mode, trade_direction, 0)
             .unwrap();
 
             pool.apply_swap_result(&swap_result_0, fee_mode, 0).unwrap();
             // swap back
 
             let swap_result_1 = pool
-            .get_swap_result(swap_result_0.output_amount, fee_mode, TradeDirection::BtoA, 0)
+            .get_swap_result_with_amount_in(swap_result_0.output_amount, fee_mode, TradeDirection::BtoA, 0)
             .unwrap();
 
             assert!(swap_result_1.output_amount < amount_in);
@@ -70,14 +70,14 @@ proptest! {
         let max_amount_in = pool.get_max_amount_in(trade_direction).unwrap();
         if amount_in <= max_amount_in {
             let swap_result_0 = pool
-            .get_swap_result(amount_in, fee_mode, trade_direction, 0)
+            .get_swap_result_with_amount_in(amount_in, fee_mode, trade_direction, 0)
             .unwrap();
 
             pool.apply_swap_result(&swap_result_0, fee_mode, 0).unwrap();
             // swap back
 
             let swap_result_1 = pool
-            .get_swap_result(swap_result_0.output_amount, fee_mode, TradeDirection::AtoB, 0)
+            .get_swap_result_with_amount_in(swap_result_0.output_amount, fee_mode, TradeDirection::AtoB, 0)
             .unwrap();
 
             assert!(swap_result_1.output_amount < amount_in);
@@ -101,7 +101,7 @@ proptest! {
 //     };
 
 //     let swap_result_0 = pool
-//         .get_swap_result(amount_in, false, trade_direction)
+//         .get_swap_result_with_amount_in(amount_in, false, trade_direction)
 //         .unwrap();
 
 //     println!("{:?}", swap_result_0);
@@ -110,7 +110,7 @@ proptest! {
 //         .unwrap();
 
 //     let swap_result_1 = pool
-//         .get_swap_result(swap_result_0.output_amount, false, TradeDirection::BtoA)
+//         .get_swap_result_with_amount_in(swap_result_0.output_amount, false, TradeDirection::BtoA)
 //         .unwrap();
 
 //     println!("{:?}", swap_result_1);
@@ -133,7 +133,7 @@ fn test_reserve_wont_lost_when_swap_from_b_to_a_single() {
     };
     let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, false).unwrap();
     let swap_result_0 = pool
-        .get_swap_result(amount_in, fee_mode, trade_direction, 0)
+        .get_swap_result_with_amount_in(amount_in, fee_mode, trade_direction, 0)
         .unwrap();
 
     println!("{:?}", swap_result_0);
@@ -141,7 +141,7 @@ fn test_reserve_wont_lost_when_swap_from_b_to_a_single() {
     pool.apply_swap_result(&swap_result_0, fee_mode, 0).unwrap();
 
     let swap_result_1 = pool
-        .get_swap_result(
+        .get_swap_result_with_amount_in(
             swap_result_0.output_amount,
             fee_mode,
             TradeDirection::AtoB,
@@ -195,7 +195,7 @@ fn test_swap_basic() {
     let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, false).unwrap();
 
     let swap_result = pool
-        .get_swap_result(amount_in, fee_mode, trade_direction, 0)
+        .get_swap_result_with_amount_in(amount_in, fee_mode, trade_direction, 0)
         .unwrap();
 
     println!("result {:?}", swap_result);
@@ -205,7 +205,12 @@ fn test_swap_basic() {
     pool.apply_swap_result(&swap_result, fee_mode, 0).unwrap();
 
     let swap_result_referse = pool
-        .get_swap_result(swap_result.output_amount, fee_mode, TradeDirection::BtoA, 0)
+        .get_swap_result_with_amount_in(
+            swap_result.output_amount,
+            fee_mode,
+            TradeDirection::BtoA,
+            0,
+        )
         .unwrap();
 
     println!("reverse {:?}", swap_result_referse);

--- a/rust-sdk/src/quote.rs
+++ b/rust-sdk/src/quote.rs
@@ -64,8 +64,12 @@ fn get_internal_quote(
 
     let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, has_referral)?;
 
-    let swap_result =
-        pool.get_swap_result(actual_amount_in, fee_mode, trade_direction, current_point)?;
+    let swap_result = pool.get_swap_result_with_amount_in(
+        actual_amount_in,
+        fee_mode,
+        trade_direction,
+        current_point,
+    )?;
 
     Ok(swap_result)
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+tab_spaces = 4


### PR DESCRIPTION
PR:
- Support rust formatter `rustfmt.toml`.
- Refactor `(RESOLUTION * 2) as usize` to `RESOLUTION as usize * 2` to avoid potential overflows.
- Clone `swap` ix to `swap_exact_in` ix and `swap` tests to `swap_exact_in` tests to prepare for `swap_exact_out`. This action pushes the `swap` related code to legacy.
- 🆕 Support `get_next_sqrt_price_from_output`, `get_max_amount_out`.
- 🆕 Extend `SwapMode` to `get_swap_result_from_a_to_b` and `get_swap_result_from_b_to_a`
- Rename `get_swap_result` to `get_swap_result_with_amount_in` and 🆕 Support `get_swap_result_with_amount_out`.
- 🆕 Add `ix_swap_exact_out`.
- 🆕 Add `swap_exact_out_tests.rs`

After passing all the tests and reviews, we must open the ix to public by adding the below to `src/lib.rs`:
```rs
pub fn swap_exact_out(
    ctx: Context<SwapExactOutCtx>,
    params: SwapExactOutParameters,
) -> Result<()> {
    instructions::handle_swap_exact_out(ctx, params)
}
```