### PR TITLE
poc: pinocchio swap hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,6 +739,8 @@ dependencies = [
  "num",
  "num-traits",
  "num_enum",
+ "pinocchio",
+ "pinocchio-token",
  "proptest",
  "ruint",
  "spl-token-metadata-interface",
@@ -910,9 +912,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "five8_const"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b4f62f0f8ca357f93ae90c8c2dd1041a1f665fde2f889ea9b1787903829015"
+checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
 dependencies = [
  "five8_core",
 ]
@@ -1430,6 +1432,33 @@ dependencies = [
  "memchr",
  "thiserror 2.0.12",
  "ucd-trie",
+]
+
+[[package]]
+name = "pinocchio"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5123fe61ac87a327d434d530eaddaaf65069a37e33e5c9f798feaed29e4974c8"
+
+[[package]]
+name = "pinocchio-pubkey"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0225638cadcbebae8932cb7f49cb5da7c15c21beb19f048f05a5ca7d93f065"
+dependencies = [
+ "five8_const",
+ "pinocchio",
+ "sha2-const-stable",
+]
+
+[[package]]
+name = "pinocchio-token"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb3a10d04ea7a633c01c4fe68eb650b4606cee4a3977bd1a1259cba324abafb"
+dependencies = [
+ "pinocchio",
+ "pinocchio-pubkey",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "num_enum",
  "pinocchio",
  "pinocchio-token",
+ "pinocchio-token-2022",
  "proptest",
  "ruint",
  "spl-token-metadata-interface",
@@ -1437,14 +1438,12 @@ dependencies = [
 [[package]]
 name = "pinocchio"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5123fe61ac87a327d434d530eaddaaf65069a37e33e5c9f798feaed29e4974c8"
+source = "git+https://github.com/anza-xyz/pinocchio.git?rev=17b0e862c01a868ea07ef81a2f8a9b4a504bdfed#17b0e862c01a868ea07ef81a2f8a9b4a504bdfed"
 
 [[package]]
 name = "pinocchio-pubkey"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0225638cadcbebae8932cb7f49cb5da7c15c21beb19f048f05a5ca7d93f065"
+source = "git+https://github.com/anza-xyz/pinocchio.git?rev=17b0e862c01a868ea07ef81a2f8a9b4a504bdfed#17b0e862c01a868ea07ef81a2f8a9b4a504bdfed"
 dependencies = [
  "five8_const",
  "pinocchio",
@@ -1454,8 +1453,16 @@ dependencies = [
 [[package]]
 name = "pinocchio-token"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb3a10d04ea7a633c01c4fe68eb650b4606cee4a3977bd1a1259cba324abafb"
+source = "git+https://github.com/anza-xyz/pinocchio.git?rev=17b0e862c01a868ea07ef81a2f8a9b4a504bdfed#17b0e862c01a868ea07ef81a2f8a9b4a504bdfed"
+dependencies = [
+ "pinocchio",
+ "pinocchio-pubkey",
+]
+
+[[package]]
+name = "pinocchio-token-2022"
+version = "0.1.0"
+source = "git+https://github.com/anza-xyz/pinocchio.git?rev=17b0e862c01a868ea07ef81a2f8a9b4a504bdfed#17b0e862c01a868ea07ef81a2f8a9b4a504bdfed"
 dependencies = [
  "pinocchio",
  "pinocchio-pubkey",

--- a/programs/cp-amm/Cargo.toml
+++ b/programs/cp-amm/Cargo.toml
@@ -13,7 +13,7 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
-default = []
+default = ["no-entrypoint"]
 local = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 devnet = []
@@ -29,6 +29,8 @@ num_enum = "0.7.0"
 num = "0.4.3"
 spl-token-metadata-interface = { version = "=0.6.0" }
 const-crypto = "0.3.0"
+pinocchio = "0.9.0"
+pinocchio-token = "0.4.0"
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/programs/cp-amm/Cargo.toml
+++ b/programs/cp-amm/Cargo.toml
@@ -29,8 +29,10 @@ num_enum = "0.7.0"
 num = "0.4.3"
 spl-token-metadata-interface = { version = "=0.6.0" }
 const-crypto = "0.3.0"
-pinocchio = "0.9.0"
-pinocchio-token = "0.4.0"
+pinocchio = { git = "https://github.com/anza-xyz/pinocchio.git", rev = "17b0e862c01a868ea07ef81a2f8a9b4a504bdfed" }
+pinocchio-token = { git = "https://github.com/anza-xyz/pinocchio.git", rev = "17b0e862c01a868ea07ef81a2f8a9b4a504bdfed" }
+# token-2022 is not released
+pinocchio-token-2022 = { git = "https://github.com/anza-xyz/pinocchio.git", rev = "17b0e862c01a868ea07ef81a2f8a9b4a504bdfed" }
 
 [dev-dependencies]
 proptest = "1.2.0"

--- a/programs/cp-amm/src/entrypoint.rs
+++ b/programs/cp-amm/src/entrypoint.rs
@@ -1,0 +1,53 @@
+use anchor_lang::{
+    prelude::{event::EVENT_IX_TAG_LE, *},
+    solana_program,
+};
+
+use crate::{entry, p_event_dispatch, p_handle_swap, SWAP_IX_ACCOUNTS};
+
+#[inline(always)]
+unsafe fn p_entrypoint(input: *mut u8) -> Option<u64> {
+    const UNINIT: core::mem::MaybeUninit<pinocchio::account_info::AccountInfo> =
+        core::mem::MaybeUninit::<pinocchio::account_info::AccountInfo>::uninit();
+    // Create an array of uninitialized account infos.
+    let mut accounts = [UNINIT; SWAP_IX_ACCOUNTS];
+
+    let (program_id, count, instruction_data) =
+        pinocchio::entrypoint::deserialize::<SWAP_IX_ACCOUNTS>(input, &mut accounts);
+
+    let accounts = core::slice::from_raw_parts(accounts.as_ptr() as _, count);
+    let result = if instruction_data.starts_with(crate::instruction::Swap::DISCRIMINATOR) {
+        Some(p_handle_swap(&program_id, accounts, &instruction_data))
+    } else if instruction_data.starts_with(EVENT_IX_TAG_LE) {
+        Some(p_event_dispatch(&program_id, accounts, &instruction_data))
+    } else {
+        None
+    };
+
+    result.map(|value| match value {
+        Ok(()) => solana_program::entrypoint::SUCCESS,
+        Err(error) => {
+            error.log();
+            anchor_lang::solana_program::program_error::ProgramError::from(error).into()
+        }
+    })
+}
+
+/// Hot path pinocchio entrypoint with anchor fallback otherwise
+#[no_mangle]
+pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
+    match p_entrypoint(input) {
+        Some(result) => result,
+        None => {
+            let (program_id, accounts, instruction_data) =
+                unsafe { solana_program::entrypoint::deserialize(input) };
+
+            match entry(program_id, &accounts, instruction_data) {
+                Ok(()) => solana_program::entrypoint::SUCCESS,
+                Err(error) => error.into(),
+            }
+        }
+    }
+}
+solana_program::custom_heap_default!();
+solana_program::custom_panic_default!();

--- a/programs/cp-amm/src/instructions/ix_swap.rs
+++ b/programs/cp-amm/src/instructions/ix_swap.rs
@@ -203,3 +203,315 @@ pub fn handle_swap(ctx: Context<SwapCtx>, params: SwapParameters) -> Result<()> 
 
     Ok(())
 }
+
+pub fn get_trade_direction(
+    input_token_account: &pinocchio_token::state::TokenAccount,
+    token_a_mint: &pinocchio::account_info::AccountInfo,
+) -> TradeDirection {
+    if input_token_account.mint() == token_a_mint.key() {
+        return TradeDirection::AtoB;
+    }
+    TradeDirection::BtoA
+}
+
+const EVENT_AUTHORITY_SEEDS: &[u8] = b"__event_authority";
+pub const EVENT_AUTHORITY_AND_BUMP: (pinocchio::pubkey::Pubkey, u8) = {
+    let (address, bump) = const_crypto::ed25519::derive_program_address(&[EVENT_AUTHORITY_SEEDS], &crate::ID_CONST.to_bytes());
+    (address, bump)
+};
+
+/// A pinocchio equivalent of the above handle_swap
+/// 
+/// To be done
+/// - Verify validation is sufficient
+/// - Support token 2022
+/// - ...
+pub fn p_handle_swap(
+    _program_id: &pinocchio::pubkey::Pubkey,
+    accounts: &[pinocchio::account_info::AccountInfo],
+    data: &[u8],
+) -> Result<()> {
+    let [
+        pool_authority,
+        // #[account(mut, has_one = token_a_vault, has_one = token_b_vault)]
+        pool,
+        input_token_account,
+        output_token_account,
+        // #[account(mut, token::token_program = token_a_program, token::mint = token_a_mint)]
+        token_a_vault,
+        // #[account(mut, token::token_program = token_b_program, token::mint = token_b_mint)]
+        token_b_vault,
+        token_a_mint,
+        token_b_mint,
+        payer,
+        token_a_program,
+        token_b_program,
+        referral_token_account, 
+        event_authority,
+        _program,
+        ..
+    ] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys.into());
+    };
+
+    // We should return identical errors as anchor on constraints to keep it simple
+    require!(payer.is_signer(), PoolError::PoolDisabled);
+
+    let pool_key = pool.key();
+    let mut pool_data = pool.try_borrow_mut_data().unwrap();
+    
+    require!(pool.owner() == &crate::ID.to_bytes(), PoolError::PoolDisabled);
+    let pool = pool_load_mut(&mut pool_data).unwrap();
+    require!(&pool.token_a_vault.to_bytes() == token_a_vault.key(), PoolError::PoolDisabled);
+    require!(&pool.token_b_vault.to_bytes() == token_b_vault.key(), PoolError::PoolDisabled);
+
+    require!(&pool.token_a_mint.to_bytes() == token_a_mint.key(), PoolError::PoolDisabled);
+    require!(&pool.token_b_mint.to_bytes() == token_b_mint.key(), PoolError::PoolDisabled);
+
+    require!(token_a_mint.owner() == token_a_program.key(), PoolError::PoolDisabled);
+    require!(token_a_mint.owner() == token_b_program.key(), PoolError::PoolDisabled);
+
+    require!(event_authority.key() == &EVENT_AUTHORITY_AND_BUMP.0, PoolError::PoolDisabled);
+
+    {
+        let access_validator = get_pool_access_validator(&pool)?;
+        require!(
+            access_validator.can_swap(&Pubkey::new_from_array(*payer.key())),
+            PoolError::PoolDisabled
+        );
+    }
+
+    let params = SwapParameters::deserialize(&mut &data[8..]).unwrap();
+    let SwapParameters {
+        amount_in,
+        minimum_amount_out,
+    } = params;
+
+    let p_input_token_account =
+        pinocchio_token::state::TokenAccount::from_account_info(input_token_account).unwrap();
+    let trade_direction = get_trade_direction(&p_input_token_account, token_a_mint);
+    drop(p_input_token_account);
+    let (
+        token_in_mint,
+        token_out_mint,
+        input_vault_account,
+        output_vault_account,
+        input_program,
+        output_program,
+    ) = match trade_direction {
+        TradeDirection::AtoB => (
+            token_a_mint,
+            token_b_mint,
+            token_a_vault,
+            token_b_vault,
+            token_a_program,
+            token_b_program,
+        ),
+        TradeDirection::BtoA => (
+            token_b_mint,
+            token_a_mint,
+            token_b_vault,
+            token_a_vault,
+            token_b_program,
+            token_a_program,
+        ),
+    };
+
+    // let transfer_fee_excluded_amount_in =
+    //     calculate_transfer_fee_excluded_amount(&token_in_mint, amount_in)?.amount;
+    let transfer_fee_excluded_amount_in = amount_in;
+
+    require!(transfer_fee_excluded_amount_in > 0, PoolError::AmountIsZero);
+
+    let has_referral = referral_token_account.key() != &crate::ID.to_bytes();
+
+    // update for dynamic fee reference
+    let current_timestamp = Clock::get()?.unix_timestamp as u64;
+    pool.update_pre_swap(current_timestamp)?;
+
+    let current_point = ActivationHandler::get_current_point(pool.activation_type)?;
+    let fee_mode = &FeeMode::get_fee_mode(pool.collect_fee_mode, trade_direction, has_referral)?;
+
+    let swap_result = pool.get_swap_result(
+        transfer_fee_excluded_amount_in,
+        fee_mode,
+        trade_direction,
+        current_point,
+    )?;
+
+    // let transfer_fee_excluded_amount_out =
+    //     calculate_transfer_fee_excluded_amount(&token_out_mint, swap_result.output_amount)?.amount;
+    let transfer_fee_excluded_amount_out = swap_result.output_amount;
+    require!(
+        transfer_fee_excluded_amount_out >= minimum_amount_out,
+        PoolError::ExceededSlippage
+    );
+
+    pool.apply_swap_result(&swap_result, fee_mode, current_timestamp)?;
+
+    // send to reserve
+    p_transfer_from_user(
+        payer,
+        token_in_mint,
+        input_token_account,
+        input_vault_account,
+        input_program,
+        amount_in,
+    )?;
+    // send to user
+    p_transfer_from_pool(
+        pool_authority,
+        &token_out_mint,
+        &output_vault_account,
+        &output_token_account,
+        output_program,
+        swap_result.output_amount,
+    )?;
+    // send to referral
+    if has_referral {
+        if fee_mode.fees_on_token_a {
+            p_transfer_from_pool(
+                pool_authority,
+                token_a_mint,
+                token_a_vault,
+                referral_token_account,
+                token_a_program,
+                swap_result.referral_fee,
+            )?;
+        } else {
+            p_transfer_from_pool(
+                pool_authority,
+                token_b_mint,
+                token_b_vault,
+                referral_token_account,
+                token_b_program,
+                swap_result.referral_fee,
+            )?;
+        }
+    }
+
+    p_emit_cpi(EvtSwap {
+        pool: Pubkey::new_from_array(*pool_key),
+        trade_direction: trade_direction.into(),
+        params,
+        swap_result,
+        has_referral,
+        actual_amount_in: transfer_fee_excluded_amount_in,
+        current_timestamp,
+    }, event_authority).unwrap();
+
+    Ok(())
+}
+
+pub fn pool_load_mut(data: &mut [u8]) -> Result<&mut Pool> {
+    let disc = Pool::DISCRIMINATOR;
+    if data.len() < disc.len() {
+        return Err(ErrorCode::AccountDiscriminatorNotFound.into());
+    }
+
+    let given_disc = &data[..disc.len()];
+    if given_disc != disc {
+        return Err(ErrorCode::AccountDiscriminatorMismatch.into());
+    }
+
+    Ok(unsafe { &mut *(data[8..].as_mut_ptr() as *mut Pool) })
+}
+
+pub fn p_transfer_from_user(
+    authority: &pinocchio::account_info::AccountInfo,
+    token_mint: &pinocchio::account_info::AccountInfo,
+    token_owner_account: &pinocchio::account_info::AccountInfo,
+    destination_token_account: &pinocchio::account_info::AccountInfo,
+    token_program: &pinocchio::account_info::AccountInfo,
+    amount: u64,
+) -> Result<()> {
+    pinocchio_token::instructions::Transfer {
+        from: token_owner_account,
+        to: destination_token_account,
+        authority,
+        amount,
+    }
+    .invoke()
+    .unwrap();
+    // let instruction = spl_token_2022::instruction::transfer_checked(
+    //     token_program.key,
+    //     &token_owner_account.key(),
+    //     &token_mint.key(),
+    //     destination_account.key,
+    //     authority.key,
+    //     &[],
+    //     amount,
+    //     token_mint.decimals,
+    // )?;
+
+    // let account_infos = vec![
+    //     token_owner_account.to_account_info(),
+    //     token_mint.to_account_info(),
+    //     destination_account.to_account_info(),
+    //     authority.to_account_info(),
+    // ];
+
+    // invoke_signed(&instruction, &account_infos, &[])?;
+
+    Ok(())
+}
+
+pub fn p_transfer_from_pool(
+    pool_authority: &pinocchio::account_info::AccountInfo,
+    token_mint: &pinocchio::account_info::AccountInfo,
+    token_vault: &pinocchio::account_info::AccountInfo,
+    token_owner_account: &pinocchio::account_info::AccountInfo,
+    token_program: &pinocchio::account_info::AccountInfo,
+    amount: u64,
+) -> Result<()> {
+    let seeds = pinocchio::seeds!(
+        crate::constants::seeds::POOL_AUTHORITY_PREFIX,
+        &[crate::const_pda::pool_authority::BUMP]
+    );
+
+    pinocchio_token::instructions::Transfer {
+        from: token_vault,
+        to: token_owner_account,
+        authority: pool_authority,
+        amount,
+    }
+    .invoke_signed(&[pinocchio::instruction::Signer::from(&seeds)])
+    .unwrap();
+
+    // let instruction = spl_token_2022::instruction::transfer_checked(
+    //     token_program.key,
+    //     &token_vault.key(),
+    //     &token_mint.key(),
+    //     &token_owner_account.key(),
+    //     &pool_authority.key(),
+    //     &[],
+    //     amount,
+    //     token_mint.decimals,
+    // )?;
+
+    // let account_infos = vec![
+    //     token_vault.to_account_info(),
+    //     token_mint.to_account_info(),
+    //     token_owner_account.to_account_info(),
+    //     pool_authority.to_account_info(),
+    // ];
+
+    // invoke_signed(&instruction, &account_infos, &[&signer_seeds[..]])?;
+
+    Ok(())
+}
+
+fn p_emit_cpi(evt_swap: EvtSwap, authority_info: &pinocchio::account_info::AccountInfo) -> pinocchio::ProgramResult {
+    let disc = anchor_lang::event::EVENT_IX_TAG_LE;
+    let inner_data = anchor_lang::Event::data(&evt_swap);
+    let ix_data: Vec<u8> = disc
+        .into_iter()
+        .map(|b| *b)
+        .chain(inner_data.into_iter())
+        .collect();
+    let instruction = pinocchio::instruction::Instruction { program_id: &crate::ID.to_bytes(), data: &ix_data, accounts: &[
+        pinocchio::instruction::AccountMeta::new(authority_info.key(), false, true)
+    ] };
+
+    pinocchio::cpi::invoke_signed(&instruction, &[authority_info], &[pinocchio::instruction::Signer::from(&pinocchio::seeds!(EVENT_AUTHORITY_SEEDS, &[EVENT_AUTHORITY_AND_BUMP.1]))])
+}

--- a/programs/cp-amm/src/instructions/ix_swap.rs
+++ b/programs/cp-amm/src/instructions/ix_swap.rs
@@ -214,12 +214,6 @@ pub fn get_trade_direction(
     TradeDirection::BtoA
 }
 
-const EVENT_AUTHORITY_SEEDS: &[u8] = b"__event_authority";
-pub const EVENT_AUTHORITY_AND_BUMP: (pinocchio::pubkey::Pubkey, u8) = {
-    let (address, bump) = const_crypto::ed25519::derive_program_address(&[EVENT_AUTHORITY_SEEDS], &crate::ID_CONST.to_bytes());
-    (address, bump)
-};
-
 /// A pinocchio equivalent of the above handle_swap
 /// 
 /// To be done
@@ -271,7 +265,7 @@ pub fn p_handle_swap(
     require!(token_a_mint.owner() == token_a_program.key(), PoolError::PoolDisabled);
     require!(token_a_mint.owner() == token_b_program.key(), PoolError::PoolDisabled);
 
-    require!(event_authority.key() == &EVENT_AUTHORITY_AND_BUMP.0, PoolError::PoolDisabled);
+    require!(event_authority.key() == &crate::EVENT_AUTHORITY_AND_BUMP.0, PoolError::PoolDisabled);
 
     {
         let access_validator = get_pool_access_validator(&pool)?;
@@ -513,5 +507,5 @@ fn p_emit_cpi(evt_swap: EvtSwap, authority_info: &pinocchio::account_info::Accou
         pinocchio::instruction::AccountMeta::new(authority_info.key(), false, true)
     ] };
 
-    pinocchio::cpi::invoke_signed(&instruction, &[authority_info], &[pinocchio::instruction::Signer::from(&pinocchio::seeds!(EVENT_AUTHORITY_SEEDS, &[EVENT_AUTHORITY_AND_BUMP.1]))])
+    pinocchio::cpi::invoke_signed(&instruction, &[authority_info], &[pinocchio::instruction::Signer::from(&pinocchio::seeds!(crate::EVENT_AUTHORITY_SEEDS, &[crate::EVENT_AUTHORITY_AND_BUMP.1]))])
 }

--- a/programs/cp-amm/src/instructions/ix_swap.rs
+++ b/programs/cp-amm/src/instructions/ix_swap.rs
@@ -16,6 +16,9 @@ pub struct SwapParameters {
     pub minimum_amount_out: u64,
 }
 
+
+pub const SWAP_IX_ACCOUNTS: usize = 14;
+
 #[event_cpi]
 #[derive(Accounts)]
 pub struct SwapCtx<'info> {

--- a/programs/cp-amm/src/lib.rs
+++ b/programs/cp-amm/src/lib.rs
@@ -1,9 +1,6 @@
 #![allow(unexpected_cfgs)]
 
-use anchor_lang::{
-    prelude::{event::EVENT_IX_TAG_LE, *},
-    solana_program,
-};
+use anchor_lang::prelude::*;
 
 #[macro_use]
 pub mod macros;

--- a/tests/bankrun-utils/common.ts
+++ b/tests/bankrun-utils/common.ts
@@ -8,6 +8,7 @@ import {
 import { BanksClient, ProgramTestContext, startAnchor } from "solana-bankrun";
 import { CP_AMM_PROGRAM_ID } from "./constants";
 import BN from "bn.js";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 export async function startTest(root: Keypair) {
   // Program name need to match fixtures program name
@@ -18,6 +19,11 @@ export async function startTest(root: Keypair) {
         name: "cp_amm",
         programId: new PublicKey(CP_AMM_PROGRAM_ID),
       },
+      // Use this to observe on p-token
+      // {
+      //   name: "pinocchio_token_program",
+      //   programId: TOKEN_PROGRAM_ID,
+      // },
     ],
     [
       {
@@ -288,5 +294,5 @@ export function randomID(min = 0, max = 10000) {
 
 export async function warpSlotBy(context: ProgramTestContext, slots: BN) {
   const clock = await context.banksClient.getClock();
-   context.warpToSlot(clock.slot + BigInt(slots.toString()));
+  context.warpToSlot(clock.slot + BigInt(slots.toString()));
 }

--- a/tests/swap.test.ts
+++ b/tests/swap.test.ts
@@ -167,159 +167,159 @@ describe("Swap token", () => {
     });
   });
 
-  // describe("Token 2022", () => {
-  //   let context: ProgramTestContext;
-  //   let admin: Keypair;
-  //   let user: Keypair;
-  //   let creator: Keypair;
-  //   let config: PublicKey;
-  //   let liquidity: BN;
-  //   let sqrtPrice: BN;
-  //   let pool: PublicKey;
-  //   let position: PublicKey;
+  describe("Token 2022", () => {
+    let context: ProgramTestContext;
+    let admin: Keypair;
+    let user: Keypair;
+    let creator: Keypair;
+    let config: PublicKey;
+    let liquidity: BN;
+    let sqrtPrice: BN;
+    let pool: PublicKey;
+    let position: PublicKey;
 
-  //   let inputTokenMint: PublicKey;
-  //   let outputTokenMint: PublicKey;
+    let inputTokenMint: PublicKey;
+    let outputTokenMint: PublicKey;
 
-  //   beforeEach(async () => {
-  //     const root = Keypair.generate();
-  //     context = await startTest(root);
+    beforeEach(async () => {
+      const root = Keypair.generate();
+      context = await startTest(root);
 
-  //     const inputTokenMintKeypair = Keypair.generate();
-  //     const outputTokenMintKeypair = Keypair.generate();
-  //     inputTokenMint = inputTokenMintKeypair.publicKey;
-  //     outputTokenMint = outputTokenMintKeypair.publicKey;
+      const inputTokenMintKeypair = Keypair.generate();
+      const outputTokenMintKeypair = Keypair.generate();
+      inputTokenMint = inputTokenMintKeypair.publicKey;
+      outputTokenMint = outputTokenMintKeypair.publicKey;
 
-  //     const inputMintExtension = [
-  //       createTransferFeeExtensionWithInstruction(inputTokenMint),
-  //     ];
-  //     const outputMintExtension = [
-  //       createTransferFeeExtensionWithInstruction(outputTokenMint),
-  //     ];
-  //     const extensions = [...inputMintExtension, ...outputMintExtension];
-  //     user = await generateKpAndFund(context.banksClient, context.payer);
-  //     admin = await generateKpAndFund(context.banksClient, context.payer);
-  //     creator = await generateKpAndFund(context.banksClient, context.payer);
+      const inputMintExtension = [
+        createTransferFeeExtensionWithInstruction(inputTokenMint),
+      ];
+      const outputMintExtension = [
+        createTransferFeeExtensionWithInstruction(outputTokenMint),
+      ];
+      const extensions = [...inputMintExtension, ...outputMintExtension];
+      user = await generateKpAndFund(context.banksClient, context.payer);
+      admin = await generateKpAndFund(context.banksClient, context.payer);
+      creator = await generateKpAndFund(context.banksClient, context.payer);
 
-  //     await createToken2022(
-  //       context.banksClient,
-  //       context.payer,
-  //       inputMintExtension,
-  //       inputTokenMintKeypair
-  //     );
-  //     await createToken2022(
-  //       context.banksClient,
-  //       context.payer,
-  //       outputMintExtension,
-  //       outputTokenMintKeypair
-  //     );
+      await createToken2022(
+        context.banksClient,
+        context.payer,
+        inputMintExtension,
+        inputTokenMintKeypair
+      );
+      await createToken2022(
+        context.banksClient,
+        context.payer,
+        outputMintExtension,
+        outputTokenMintKeypair
+      );
 
-  //     await mintToToken2022(
-  //       context.banksClient,
-  //       context.payer,
-  //       inputTokenMint,
-  //       context.payer,
-  //       user.publicKey
-  //     );
+      await mintToToken2022(
+        context.banksClient,
+        context.payer,
+        inputTokenMint,
+        context.payer,
+        user.publicKey
+      );
 
-  //     await mintToToken2022(
-  //       context.banksClient,
-  //       context.payer,
-  //       outputTokenMint,
-  //       context.payer,
-  //       user.publicKey
-  //     );
+      await mintToToken2022(
+        context.banksClient,
+        context.payer,
+        outputTokenMint,
+        context.payer,
+        user.publicKey
+      );
 
-  //     await mintToToken2022(
-  //       context.banksClient,
-  //       context.payer,
-  //       inputTokenMint,
-  //       context.payer,
-  //       creator.publicKey
-  //     );
+      await mintToToken2022(
+        context.banksClient,
+        context.payer,
+        inputTokenMint,
+        context.payer,
+        creator.publicKey
+      );
 
-  //     await mintToToken2022(
-  //       context.banksClient,
-  //       context.payer,
-  //       outputTokenMint,
-  //       context.payer,
-  //       creator.publicKey
-  //     );
+      await mintToToken2022(
+        context.banksClient,
+        context.payer,
+        outputTokenMint,
+        context.payer,
+        creator.publicKey
+      );
 
-  //     // create config
-  //     const createConfigParams: CreateConfigParams = {
-  //       poolFees: {
-  //         baseFee: {
-  //           cliffFeeNumerator: new BN(2_500_000),
-  //           numberOfPeriod: 0,
-  //           reductionFactor: new BN(0),
-  //           periodFrequency: new BN(0),
-  //           feeSchedulerMode: 0,
-  //         },
-  //         padding: [],
-  //         dynamicFee: null,
-  //       },
-  //       sqrtMinPrice: new BN(MIN_SQRT_PRICE),
-  //       sqrtMaxPrice: new BN(MAX_SQRT_PRICE),
-  //       vaultConfigKey: PublicKey.default,
-  //       poolCreatorAuthority: PublicKey.default,
-  //       activationType: 0,
-  //       collectFeeMode: 0,
-  //     };
+      // create config
+      const createConfigParams: CreateConfigParams = {
+        poolFees: {
+          baseFee: {
+            cliffFeeNumerator: new BN(2_500_000),
+            numberOfPeriod: 0,
+            reductionFactor: new BN(0),
+            periodFrequency: new BN(0),
+            feeSchedulerMode: 0,
+          },
+          padding: [],
+          dynamicFee: null,
+        },
+        sqrtMinPrice: new BN(MIN_SQRT_PRICE),
+        sqrtMaxPrice: new BN(MAX_SQRT_PRICE),
+        vaultConfigKey: PublicKey.default,
+        poolCreatorAuthority: PublicKey.default,
+        activationType: 0,
+        collectFeeMode: 0,
+      };
 
-  //     config = await createConfigIx(
-  //       context.banksClient,
-  //       admin,
-  //       new BN(randomID()),
-  //       createConfigParams
-  //     );
+      config = await createConfigIx(
+        context.banksClient,
+        admin,
+        new BN(randomID()),
+        createConfigParams
+      );
 
-  //     liquidity = new BN(MIN_LP_AMOUNT);
-  //     sqrtPrice = new BN(MIN_SQRT_PRICE.muln(2));
+      liquidity = new BN(MIN_LP_AMOUNT);
+      sqrtPrice = new BN(MIN_SQRT_PRICE.muln(2));
 
-  //     const initPoolParams: InitializePoolParams = {
-  //       payer: creator,
-  //       creator: creator.publicKey,
-  //       config,
-  //       tokenAMint: inputTokenMint,
-  //       tokenBMint: outputTokenMint,
-  //       liquidity,
-  //       sqrtPrice,
-  //       activationPoint: null,
-  //     };
+      const initPoolParams: InitializePoolParams = {
+        payer: creator,
+        creator: creator.publicKey,
+        config,
+        tokenAMint: inputTokenMint,
+        tokenBMint: outputTokenMint,
+        liquidity,
+        sqrtPrice,
+        activationPoint: null,
+      };
 
-  //     const result = await initializePool(context.banksClient, initPoolParams);
-  //     pool = result.pool;
-  //     position = await createPosition(
-  //       context.banksClient,
-  //       user,
-  //       user.publicKey,
-  //       pool
-  //     );
-  //   });
+      const result = await initializePool(context.banksClient, initPoolParams);
+      pool = result.pool;
+      position = await createPosition(
+        context.banksClient,
+        user,
+        user.publicKey,
+        pool
+      );
+    });
 
-  //   it("User swap A->B", async () => {
-  //     const addLiquidityParams: AddLiquidityParams = {
-  //       owner: user,
-  //       pool,
-  //       position,
-  //       liquidityDelta: new BN(MIN_SQRT_PRICE.muln(30)),
-  //       tokenAAmountThreshold: new BN(200),
-  //       tokenBAmountThreshold: new BN(200),
-  //     };
-  //     await addLiquidity(context.banksClient, addLiquidityParams);
+    it("User swap A->B", async () => {
+      const addLiquidityParams: AddLiquidityParams = {
+        owner: user,
+        pool,
+        position,
+        liquidityDelta: new BN(MIN_SQRT_PRICE.muln(30)),
+        tokenAAmountThreshold: new BN(200),
+        tokenBAmountThreshold: new BN(200),
+      };
+      await addLiquidity(context.banksClient, addLiquidityParams);
 
-  //     const swapParams: SwapParams = {
-  //       payer: user,
-  //       pool,
-  //       inputTokenMint,
-  //       outputTokenMint,
-  //       amountIn: new BN(10),
-  //       minimumAmountOut: new BN(0),
-  //       referralTokenAccount: null,
-  //     };
+      const swapParams: SwapParams = {
+        payer: user,
+        pool,
+        inputTokenMint,
+        outputTokenMint,
+        amountIn: new BN(10),
+        minimumAmountOut: new BN(0),
+        referralTokenAccount: null,
+      };
 
-  //     await swap(context.banksClient, swapParams);
-  //   });
-  // });
+      await swap(context.banksClient, swapParams);
+    });
+  });
 });

--- a/tests/swap.test.ts
+++ b/tests/swap.test.ts
@@ -167,159 +167,159 @@ describe("Swap token", () => {
     });
   });
 
-  describe("Token 2022", () => {
-    let context: ProgramTestContext;
-    let admin: Keypair;
-    let user: Keypair;
-    let creator: Keypair;
-    let config: PublicKey;
-    let liquidity: BN;
-    let sqrtPrice: BN;
-    let pool: PublicKey;
-    let position: PublicKey;
+  // describe("Token 2022", () => {
+  //   let context: ProgramTestContext;
+  //   let admin: Keypair;
+  //   let user: Keypair;
+  //   let creator: Keypair;
+  //   let config: PublicKey;
+  //   let liquidity: BN;
+  //   let sqrtPrice: BN;
+  //   let pool: PublicKey;
+  //   let position: PublicKey;
 
-    let inputTokenMint: PublicKey;
-    let outputTokenMint: PublicKey;
+  //   let inputTokenMint: PublicKey;
+  //   let outputTokenMint: PublicKey;
 
-    beforeEach(async () => {
-      const root = Keypair.generate();
-      context = await startTest(root);
+  //   beforeEach(async () => {
+  //     const root = Keypair.generate();
+  //     context = await startTest(root);
 
-      const inputTokenMintKeypair = Keypair.generate();
-      const outputTokenMintKeypair = Keypair.generate();
-      inputTokenMint = inputTokenMintKeypair.publicKey;
-      outputTokenMint = outputTokenMintKeypair.publicKey;
+  //     const inputTokenMintKeypair = Keypair.generate();
+  //     const outputTokenMintKeypair = Keypair.generate();
+  //     inputTokenMint = inputTokenMintKeypair.publicKey;
+  //     outputTokenMint = outputTokenMintKeypair.publicKey;
 
-      const inputMintExtension = [
-        createTransferFeeExtensionWithInstruction(inputTokenMint),
-      ];
-      const outputMintExtension = [
-        createTransferFeeExtensionWithInstruction(outputTokenMint),
-      ];
-      const extensions = [...inputMintExtension, ...outputMintExtension];
-      user = await generateKpAndFund(context.banksClient, context.payer);
-      admin = await generateKpAndFund(context.banksClient, context.payer);
-      creator = await generateKpAndFund(context.banksClient, context.payer);
+  //     const inputMintExtension = [
+  //       createTransferFeeExtensionWithInstruction(inputTokenMint),
+  //     ];
+  //     const outputMintExtension = [
+  //       createTransferFeeExtensionWithInstruction(outputTokenMint),
+  //     ];
+  //     const extensions = [...inputMintExtension, ...outputMintExtension];
+  //     user = await generateKpAndFund(context.banksClient, context.payer);
+  //     admin = await generateKpAndFund(context.banksClient, context.payer);
+  //     creator = await generateKpAndFund(context.banksClient, context.payer);
 
-      await createToken2022(
-        context.banksClient,
-        context.payer,
-        inputMintExtension,
-        inputTokenMintKeypair
-      );
-      await createToken2022(
-        context.banksClient,
-        context.payer,
-        outputMintExtension,
-        outputTokenMintKeypair
-      );
+  //     await createToken2022(
+  //       context.banksClient,
+  //       context.payer,
+  //       inputMintExtension,
+  //       inputTokenMintKeypair
+  //     );
+  //     await createToken2022(
+  //       context.banksClient,
+  //       context.payer,
+  //       outputMintExtension,
+  //       outputTokenMintKeypair
+  //     );
 
-      await mintToToken2022(
-        context.banksClient,
-        context.payer,
-        inputTokenMint,
-        context.payer,
-        user.publicKey
-      );
+  //     await mintToToken2022(
+  //       context.banksClient,
+  //       context.payer,
+  //       inputTokenMint,
+  //       context.payer,
+  //       user.publicKey
+  //     );
 
-      await mintToToken2022(
-        context.banksClient,
-        context.payer,
-        outputTokenMint,
-        context.payer,
-        user.publicKey
-      );
+  //     await mintToToken2022(
+  //       context.banksClient,
+  //       context.payer,
+  //       outputTokenMint,
+  //       context.payer,
+  //       user.publicKey
+  //     );
 
-      await mintToToken2022(
-        context.banksClient,
-        context.payer,
-        inputTokenMint,
-        context.payer,
-        creator.publicKey
-      );
+  //     await mintToToken2022(
+  //       context.banksClient,
+  //       context.payer,
+  //       inputTokenMint,
+  //       context.payer,
+  //       creator.publicKey
+  //     );
 
-      await mintToToken2022(
-        context.banksClient,
-        context.payer,
-        outputTokenMint,
-        context.payer,
-        creator.publicKey
-      );
+  //     await mintToToken2022(
+  //       context.banksClient,
+  //       context.payer,
+  //       outputTokenMint,
+  //       context.payer,
+  //       creator.publicKey
+  //     );
 
-      // create config
-      const createConfigParams: CreateConfigParams = {
-        poolFees: {
-          baseFee: {
-            cliffFeeNumerator: new BN(2_500_000),
-            numberOfPeriod: 0,
-            reductionFactor: new BN(0),
-            periodFrequency: new BN(0),
-            feeSchedulerMode: 0,
-          },
-          padding: [],
-          dynamicFee: null,
-        },
-        sqrtMinPrice: new BN(MIN_SQRT_PRICE),
-        sqrtMaxPrice: new BN(MAX_SQRT_PRICE),
-        vaultConfigKey: PublicKey.default,
-        poolCreatorAuthority: PublicKey.default,
-        activationType: 0,
-        collectFeeMode: 0,
-      };
+  //     // create config
+  //     const createConfigParams: CreateConfigParams = {
+  //       poolFees: {
+  //         baseFee: {
+  //           cliffFeeNumerator: new BN(2_500_000),
+  //           numberOfPeriod: 0,
+  //           reductionFactor: new BN(0),
+  //           periodFrequency: new BN(0),
+  //           feeSchedulerMode: 0,
+  //         },
+  //         padding: [],
+  //         dynamicFee: null,
+  //       },
+  //       sqrtMinPrice: new BN(MIN_SQRT_PRICE),
+  //       sqrtMaxPrice: new BN(MAX_SQRT_PRICE),
+  //       vaultConfigKey: PublicKey.default,
+  //       poolCreatorAuthority: PublicKey.default,
+  //       activationType: 0,
+  //       collectFeeMode: 0,
+  //     };
 
-      config = await createConfigIx(
-        context.banksClient,
-        admin,
-        new BN(randomID()),
-        createConfigParams
-      );
+  //     config = await createConfigIx(
+  //       context.banksClient,
+  //       admin,
+  //       new BN(randomID()),
+  //       createConfigParams
+  //     );
 
-      liquidity = new BN(MIN_LP_AMOUNT);
-      sqrtPrice = new BN(MIN_SQRT_PRICE.muln(2));
+  //     liquidity = new BN(MIN_LP_AMOUNT);
+  //     sqrtPrice = new BN(MIN_SQRT_PRICE.muln(2));
 
-      const initPoolParams: InitializePoolParams = {
-        payer: creator,
-        creator: creator.publicKey,
-        config,
-        tokenAMint: inputTokenMint,
-        tokenBMint: outputTokenMint,
-        liquidity,
-        sqrtPrice,
-        activationPoint: null,
-      };
+  //     const initPoolParams: InitializePoolParams = {
+  //       payer: creator,
+  //       creator: creator.publicKey,
+  //       config,
+  //       tokenAMint: inputTokenMint,
+  //       tokenBMint: outputTokenMint,
+  //       liquidity,
+  //       sqrtPrice,
+  //       activationPoint: null,
+  //     };
 
-      const result = await initializePool(context.banksClient, initPoolParams);
-      pool = result.pool;
-      position = await createPosition(
-        context.banksClient,
-        user,
-        user.publicKey,
-        pool
-      );
-    });
+  //     const result = await initializePool(context.banksClient, initPoolParams);
+  //     pool = result.pool;
+  //     position = await createPosition(
+  //       context.banksClient,
+  //       user,
+  //       user.publicKey,
+  //       pool
+  //     );
+  //   });
 
-    it("User swap A->B", async () => {
-      const addLiquidityParams: AddLiquidityParams = {
-        owner: user,
-        pool,
-        position,
-        liquidityDelta: new BN(MIN_SQRT_PRICE.muln(30)),
-        tokenAAmountThreshold: new BN(200),
-        tokenBAmountThreshold: new BN(200),
-      };
-      await addLiquidity(context.banksClient, addLiquidityParams);
+  //   it("User swap A->B", async () => {
+  //     const addLiquidityParams: AddLiquidityParams = {
+  //       owner: user,
+  //       pool,
+  //       position,
+  //       liquidityDelta: new BN(MIN_SQRT_PRICE.muln(30)),
+  //       tokenAAmountThreshold: new BN(200),
+  //       tokenBAmountThreshold: new BN(200),
+  //     };
+  //     await addLiquidity(context.banksClient, addLiquidityParams);
 
-      const swapParams: SwapParams = {
-        payer: user,
-        pool,
-        inputTokenMint,
-        outputTokenMint,
-        amountIn: new BN(10),
-        minimumAmountOut: new BN(0),
-        referralTokenAccount: null,
-      };
+  //     const swapParams: SwapParams = {
+  //       payer: user,
+  //       pool,
+  //       inputTokenMint,
+  //       outputTokenMint,
+  //       amountIn: new BN(10),
+  //       minimumAmountOut: new BN(0),
+  //       referralTokenAccount: null,
+  //     };
 
-      await swap(context.banksClient, swapParams);
-    });
-  });
+  //     await swap(context.banksClient, swapParams);
+  //   });
+  // });
 });


### PR DESCRIPTION
Keep the entire program as an anchor program but bring trivial optimisations to the hot path, swap.

Run a first pass with the pinocchio entrypoint to execute swap and the event handler.
There might be some way to translate the work from the pinocchio entrypoint to the solana entrypoint but this was not explored here as we only focus on reducing compute units for swap.

A swap event now prints 52 compute units consumed.

Focusing on spl token, consumed CUs:
Before: 40,468
After: 19,766
After with p-token: 10,756