### PR TITLE
fix: Mint Bypass Shares the Config Creation Role

### DIFF
--- a/programs/cp-amm/src/state/operator.rs
+++ b/programs/cp-amm/src/state/operator.rs
@@ -16,6 +16,7 @@ use static_assertions::const_assert_eq;
     VariantCount,
 )]
 pub enum OperatorPermission {
+    // CreateConfigKey can grant CreatePoolWithoutMintValidation on a private config. This is similar to CreateTokenBadge but on a config level
     CreateConfigKey,      // 0
     RemoveConfigKey,      // 1
     CreateTokenBadge,     // 2


### PR DESCRIPTION
This design is intentional, I added a comment to be explicit

Addresses: https://app.notion.com/p/offsidelabs/Meteora-DAMM-v2-Release-0-2-4-Audit-Draft-3cfd5242e8af8043a58af83bce855458?source=copy_link#3cfd5242e8af8080a5d7ee6f42a9a6c9